### PR TITLE
Modifications to run lib on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ exclude = ["/.github"]
 quick-xml = "0.23"
 
 [dev-dependencies]
-nix = "0.24"
 tempdir = "0.3"
 libc = "0.2"
+serial_test="0.8"
+
+[target.'cfg(unix)'.dev-dependencies]
+nix = "0.24"


### PR DESCRIPTION
Hello @CrabeDeFrance ,

Thanks for developing this crate. I attempted to use this on Windows but there were certain unix-specific dependencies present. 

I had modified these to get this running on Windows 11. The tests passed locally on Windows. Please find and review this PR. Following are the changes:

* Added Unix specific #[cfg] directives in lib.rs for imports and tests
  using nix
* Modified `test_rtshark_tshark_missing` to remove "PATH" on starting of
  test and restore at end of test
* Added `serialize_test` crate as `dev-dependencies` in `Cargo.toml` to run
  `test_rtshark_tshark_missing` and `test_rtshark_mutiple_spawn_pcap`
  serially
* Modified `dev-dependencies` to only include `nix` package on Unix
  based systems in `Cargo.toml`
  
Best,
Prabhpreet