### PR TITLE
Expose packet capture timestamp as `Packet::timestamp_micros`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtshark"
-version = "2.4.0"
+version = "2.5.0"
 edition = "2021"
 authors = ["CrabeDeFrance"]
 license = "MIT OR Apache-2.0"
@@ -16,6 +16,7 @@ exclude = ["/.github"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chrono = { version = "0.4", default-features = false }
 quick-xml = "0.27"
 
 [dev-dependencies]


### PR DESCRIPTION
For comparison, [pyshark] (Python counterpart of `rtshark`) exposes packet capture timestamp via [`Packet.sniff_time`].

[pyshark]: https://github.com/KimiNewt/pyshark
[`Packet.sniff_time`]: https://github.com/KimiNewt/pyshark/blob/c722d36e4211504893ca891993beb663dd2fc2e9/src/pyshark/tshark/output_parser/tshark_xml.py#L96