### PR TITLE
Add access to tshark version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ exclude = ["/.github"]
 [dependencies]
 chrono = { version = "0.4", default-features = false }
 quick-xml = "0.33"
+semver = "1.0.23"
 
 [dev-dependencies]
 tempdir = "0.3"


### PR DESCRIPTION
I ran into a use case where I needed a feature only available in the latest version of tshark, so I needed to know what version of tshark was being used.

The builder seemed like the most appropriate place for the new method. I suppose it could also just be a stand alone function, but that would mean that the command could never be configured (like, if someday the builder lets you set the location of tshark rather than assuming its in your path).