### PR TITLE
Implement Async Capabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,17 @@ keywords = ["wireshark", "tshark", "pcap", "network", "dissector"]
 exclude = ["/.github"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["quick-xml"]
+async = ["tokio", "tokio-stream", "quick-xml/async-tokio"]
+
 [dependencies]
 chrono = { version = "0.4", default-features = false }
-quick-xml = "0.37"
 semver = "1"
+quick-xml = { version = "0.37", optional = true }
+tokio = { version = "1.45", features = ["full"], optional = true }
+tokio-stream = { version = "0.1", optional = true }
+
 
 [dev-dependencies]
 libc = "0.2"


### PR DESCRIPTION
As referenced in issue: https://github.com/CrabeDeFrance/rtshark/issues/29

This pull request introduces asynchronous support to the `rtshark` library, allowing users to spawn and interact with TShark processes using async Rust. The changes add new features, dependencies, and an async API, making it possible to process packets concurrently and efficiently. Key updates include a new `RTSharkAsync` struct, async XML parsing, and corresponding tests.

Major changes are:
- New Async Feature Flag
- New Builder method for "spawn async"
- Several new private helper functions
- New test for async capability


**Async feature and dependency additions:**

* Added a new `async` feature in `Cargo.toml`, with optional dependencies on `tokio`, `tokio-stream`, and `quick-xml/async-tokio`, enabling asynchronous packet processing.

**Async API implementation:**

* Introduced the `RTSharkAsync` struct, providing an async interface for reading packets from TShark, along with a new `spawn_async` method in `RTSharkBuilderReady` for starting async TShark processes. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R918-R992) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R1155-R1227)
* Implemented an internal `spawn_tshark_async` helper to launch TShark as an async process, handling environment variables and error mapping.

**Async XML parsing:**

* Added the `parse_xml_async` function to asynchronously decode XML output from TShark, mirroring the synchronous parser but using async I/O primitives.

**Testing and validation:**

* Added an async integration test (`async_sandbox`) to verify the new async API, demonstrating concurrent packet reading and time tracking.

**Future Changes**
- The `parse_xml` and `parse_xml_async` methods are incredibly similar. It would be ideal to place the two methods into a single struct which could share methods.
- The lib file is starting to get large which makes the LSP and linter slow (at least for me). Recommend a refactor which breaks the methods into logical components in separate files.
- More testing would probably be good.
