### PR TITLE
adds support for capturing groups of metadata

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -69,7 +69,7 @@ impl<'a> RTSharkBuilder {
             input_path: vec![path],
             live_capture: false,
             metadata_blacklist: vec![],
-            metadata_whitelist: None,
+            metadata_whitelist: vec![],
             capture_filter: "",
             display_filter: "",
             env_path: "",
@@ -161,8 +161,8 @@ pub struct RTSharkBuilderReady<'a> {
     live_capture: bool,
     /// filter out (blacklist) useless metadata names, to prevent storing them in output packet structure
     metadata_blacklist: Vec<String>,
-    /// filter out (whitelist) useless metadata names, to prevent TShark to put them in PDML report
-    metadata_whitelist: Option<Vec<String>>,
+    /// Names of metadata fields to retain; any field not in this list is excluded from the output packet structure. No filtering is applied if empty.
+    metadata_whitelist: Vec<String>,
     /// capture_filter : string to be passed to libpcap to filter packets (let pass only packets matching this filter)
     capture_filter: &'a str,
     /// display filter : expression filter to match before TShark prints a packet
@@ -307,11 +307,7 @@ impl<'a> RTSharkBuilderReady<'a> {
     #[must_use]
     pub fn metadata_whitelist(&self, whitelist: &'a str) -> Self {
         let mut new = self.clone();
-        if let Some(wl) = &mut new.metadata_whitelist {
-            wl.push(whitelist.to_owned());
-        } else {
-            new.metadata_whitelist = Some(vec![whitelist.to_owned()]);
-        }
+        new.metadata_whitelist.push(whitelist.to_owned());
         new
     }
 
@@ -448,10 +444,10 @@ impl<'a> RTSharkBuilderReady<'a> {
     }
 
     /// Let TShark use a specific lua plugin.
-    /// 
+    ///
     /// See <https://wiki.wireshark.org/Lua/Examples#user-content-a-custom-file-reader--writer-tutorial-script> for more details.
-    /// 
-    /// 
+    ///
+    ///
     /// ### Example: Prepare an instance of TShark to use a specific plugin
     ///
     /// ```
@@ -510,7 +506,11 @@ impl<'a> RTSharkBuilderReady<'a> {
     pub fn spawn(&self) -> Result<RTShark> {
         let tshark_params = self.prepare_args_unbuffered()?;
         let tshark_child = self.spawn_tshark(&tshark_params)?;
-        Ok(RTShark::new(tshark_child, self.metadata_blacklist.clone()))
+        Ok(RTShark::new(
+            tshark_child,
+            self.metadata_blacklist.clone(),
+            self.metadata_whitelist.clone(),
+        ))
     }
 
     /// Starts an asynchronous TShark process given the provided parameters, mapped to a new [RTSharkAsync] instance.
@@ -579,6 +579,7 @@ impl<'a> RTSharkBuilderReady<'a> {
         Ok(crate::RTSharkAsync::new(
             tshark_child,
             self.metadata_blacklist.clone(),
+            self.metadata_whitelist.clone(),
         ))
     }
 
@@ -728,12 +729,6 @@ impl<'a> RTSharkBuilderReady<'a> {
             tshark_params.extend(&["-o", option]);
         }
 
-        if let Some(wl) = &self.metadata_whitelist {
-            for whitelist_elem in wl {
-                tshark_params.extend(&["-e", whitelist_elem]);
-            }
-        }
-
         for protocol in &self.disabled_protocols {
             tshark_params.extend(&["--disable-protocol", protocol]);
         }
@@ -796,7 +791,6 @@ mod tests {
 
         tmp_dir.close().expect("Error deleting fifo dir");
     }
-
 
     #[test]
     fn test_plugin() {

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,5 +1,14 @@
 use crate::metadata::Metadata;
 
+/// A group of [Metadata] sharing a common parent field, as found in the original packet tree.
+/// Returned by [Layer::groups].
+pub struct MetadataGroup<'a> {
+    /// The parent field (e.g. `tls.record`)
+    pub parent: &'a Metadata,
+    /// The child fields that fall within the parent's byte range
+    pub fields: Vec<&'a Metadata>,
+}
+
 /// A layer is a protocol in the protocol stack of a packet (example: IP layer). It may contain multiple [Metadata].
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct Layer {
@@ -76,6 +85,45 @@ impl Layer {
     /// ```
     pub fn metadata(&self, name: &str) -> Option<&Metadata> {
         self.metadata.iter().find(|m| m.name().eq(name))
+    }
+
+    /// Group metadata by a named parent field using byte-range containment.
+    ///
+    /// Returns one [MetadataGroup] per occurrence of `parent_name`, each containing
+    /// the child fields whose position falls within the parent's byte range.
+    /// Requires the parent field to be in the whitelist so its `pos`/`size` are populated.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// // With "tls.record", "tls.record.content_type", "tls.record.length" in the whitelist:
+    /// // for group in tls_layer.groups("tls.record") {
+    /// //     println!("{:?}", group.parent.display());
+    /// //     for field in &group.fields {
+    /// //         println!("  {} = {}", field.name(), field.value());
+    /// //     }
+    /// // }
+    /// ```
+    pub fn groups<'a>(&'a self, parent_name: &str) -> Vec<MetadataGroup<'a>> {
+        self.metadata
+            .iter()
+            .filter(|m| m.name() == parent_name)
+            .map(|parent| {
+                let fields = match (parent.position(), parent.size()) {
+                    (Some(r_pos), Some(r_size)) => self
+                        .metadata
+                        .iter()
+                        .filter(|m| {
+                            m.name() != parent_name
+                                && m.position()
+                                    .is_some_and(|p| p >= r_pos && p < r_pos + r_size)
+                        })
+                        .collect(),
+                    _ => vec![],
+                };
+                MetadataGroup { parent, fields }
+            })
+            .collect()
     }
 
     /// Get an iterator on the list of [Metadata] for this [Layer].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ mod rtshark;
 mod xml;
 
 pub use builder::{RTSharkBuilder, RTSharkBuilderReady, RTSharkVersion};
-pub use layer::Layer;
+pub use layer::{Layer, MetadataGroup};
 pub use metadata::Metadata;
 pub use packet::Packet;
 pub use rtshark::RTShark;

--- a/src/rtshark.rs
+++ b/src/rtshark.rs
@@ -20,12 +20,14 @@ pub struct RTShark {
     /// stderr
     stderr: BufReader<ChildStderr>,
     /// optional metadata blacklist, to prevent storing useless metadata in output packet structure
-    filters: Vec<String>,
+    blacklist: Vec<String>,
+    /// optional metadata whitelist, to store only the listed metadata in output packet structure
+    whitelist: Vec<String>,
 }
 
 impl RTShark {
     /// create a new RTShark instance from a successful builder call.
-    pub(crate) fn new(mut process: Child, filters: Vec<String>) -> Self {
+    pub(crate) fn new(mut process: Child, blacklist: Vec<String>, whitelist: Vec<String>) -> Self {
         let buf_reader = BufReader::new(process.stdout.take().unwrap());
         let stderr = BufReader::new(process.stderr.take().unwrap());
         let parser = quick_xml::Reader::from_reader(buf_reader);
@@ -34,7 +36,8 @@ impl RTShark {
             process: Some(process),
             parser,
             stderr,
-            filters,
+            blacklist,
+            whitelist,
         }
     }
 
@@ -74,7 +77,7 @@ impl RTShark {
     pub fn read(&mut self) -> Result<Option<Packet>> {
         let xml_reader = &mut self.parser;
 
-        let msg = RTShark::parse(xml_reader, &self.filters);
+        let msg = RTShark::parse(xml_reader, &self.blacklist, &self.whitelist);
         if let Ok(ref msg) = msg {
             let done = match msg {
                 None => {
@@ -105,7 +108,8 @@ impl RTShark {
 
     pub(crate) fn parse<B: BufRead>(
         reader: &mut Reader<B>,
-        filters: &[String],
+        blacklist: &[String],
+        whitelist: &[String],
     ) -> std::io::Result<Option<Packet>> {
         let mut parser = RTSharkParser::new();
         let mut buf = vec![];
@@ -118,7 +122,7 @@ impl RTShark {
                 )
             })?;
 
-            match parser.parse(event, filters)? {
+            match parser.parse(event, blacklist, whitelist)? {
                 ParserResult::Continue => (),
                 ParserResult::Packet(packet) => return Ok(Some(packet)),
                 ParserResult::Eof => return Ok(None),
@@ -508,9 +512,10 @@ mod tests {
             .metadata_whitelist("nosuchproto.nosuchmetadata");
         let mut rtshark = builder.spawn().unwrap();
 
-        // read a packet
-        let ret = rtshark.read();
-        assert!(ret.is_err());
+        // whitelist filtering is now done at parse time, so tshark succeeds but
+        // no metadata matching the non-existent field is stored
+        let pkt = rtshark.read().unwrap().unwrap();
+        assert!(pkt.layer_name("nosuchproto").is_none());
 
         rtshark.kill();
 
@@ -1335,5 +1340,69 @@ mod tests {
         let output = std::fs::read(output).unwrap();
 
         assert_eq!(normalized, output);
+    }
+
+    #[test]
+    fn test_tls_record_grouping() {
+        let pcap = include_bytes!("../assets/test_tls.pcap");
+
+        // write pcap to a temp file
+        let tmp_dir = tempdir::TempDir::new("test_pcap").unwrap();
+        let pcap_path = tmp_dir.path().join("test_tls.pcap");
+        let mut output = std::fs::File::create(&pcap_path).expect("unable to open file");
+        output.write_all(pcap).expect("unable to write pcap");
+        output.flush().expect("unable to flush");
+
+        // include tls.record parent so we can group children by containment
+        let builder = RTSharkBuilder::builder()
+            .input_path(pcap_path.to_str().unwrap())
+            .display_filter("frame.number == 6")
+            .metadata_whitelist("tls.record")
+            .metadata_whitelist("tls.record.content_type")
+            .metadata_whitelist("tls.record.length");
+        let mut rtshark = builder.spawn().unwrap();
+
+        let pkt = rtshark.read().unwrap().unwrap();
+        let tls = pkt.layer_name("tls").expect("expected a tls layer");
+
+        let records = tls.groups("tls.record");
+
+        assert_eq!(records.len(), 2, "expected two TLS records in this packet");
+
+        let field = |group: &crate::layer::MetadataGroup<'_>, name: &str| -> String {
+            group
+                .fields
+                .iter()
+                .find(|m| m.name() == name)
+                .map(|m| m.value().to_string())
+                .unwrap_or_else(|| "?".to_string())
+        };
+
+        // record 1: Handshake (22), length 122
+        assert_eq!(
+            field(&records[0], "tls.record.content_type"),
+            "22",
+            "first record: expected content_type 22 (Handshake)"
+        );
+        assert_eq!(
+            field(&records[0], "tls.record.length"),
+            "122",
+            "first record: expected length 122"
+        );
+
+        // record 2: Change Cipher Spec (20), length 1
+        assert_eq!(
+            field(&records[1], "tls.record.content_type"),
+            "20",
+            "second record: expected content_type 20 (Change Cipher Spec)"
+        );
+        assert_eq!(
+            field(&records[1], "tls.record.length"),
+            "1",
+            "second record: expected length 1"
+        );
+
+        rtshark.kill();
+        tmp_dir.close().expect("error deleting temp dir");
     }
 }

--- a/src/rtshark_async.rs
+++ b/src/rtshark_async.rs
@@ -15,11 +15,16 @@ pub struct RTSharkAsync {
     process: Option<tokio::process::Child>,
     parser: quick_xml::Reader<tokio::io::BufReader<tokio::process::ChildStdout>>,
     stderr: tokio::io::BufReader<tokio::process::ChildStderr>,
-    filters: Vec<String>,
+    blacklist: Vec<String>,
+    whitelist: Vec<String>,
 }
 
 impl RTSharkAsync {
-    pub(crate) fn new(mut process: tokio::process::Child, filters: Vec<String>) -> Self {
+    pub(crate) fn new(
+        mut process: tokio::process::Child,
+        blacklist: Vec<String>,
+        whitelist: Vec<String>,
+    ) -> Self {
         let buf_reader = tokio::io::BufReader::new(process.stdout.take().unwrap());
         let stderr = tokio::io::BufReader::new(process.stderr.take().unwrap());
         let parser = quick_xml::Reader::from_reader(buf_reader);
@@ -28,7 +33,8 @@ impl RTSharkAsync {
             process: Some(process),
             parser,
             stderr,
-            filters,
+            blacklist,
+            whitelist,
         }
     }
     /// Read a packet from thsark output and map it to the [Packet] type.
@@ -75,7 +81,7 @@ impl RTSharkAsync {
     /// }
     /// ```
     pub async fn read(&mut self) -> std::io::Result<Option<Packet>> {
-        let ret = RTSharkAsync::parse(&mut self.parser, &self.filters).await?;
+        let ret = RTSharkAsync::parse(&mut self.parser, &self.blacklist, &self.whitelist).await?;
         if ret.is_none() {
             self.on_eof().await?;
         }
@@ -105,7 +111,8 @@ impl RTSharkAsync {
 
     pub(crate) async fn parse<B: AsyncBufRead + Unpin>(
         reader: &mut Reader<B>,
-        filters: &[String],
+        blacklist: &[String],
+        whitelist: &[String],
     ) -> std::io::Result<Option<Packet>> {
         let mut parser = RTSharkParser::new();
         let mut buf = vec![];
@@ -118,7 +125,7 @@ impl RTSharkAsync {
                 )
             })?;
 
-            match parser.parse(event, filters)? {
+            match parser.parse(event, blacklist, whitelist)? {
                 ParserResult::Continue => (),
                 ParserResult::Packet(packet) => return Ok(Some(packet)),
                 ParserResult::Eof => return Ok(None),

--- a/src/rtshark_async.rs
+++ b/src/rtshark_async.rs
@@ -565,8 +565,8 @@ mod tests {
         let mut rtshark = builder.spawn().unwrap();
 
         // read a packet
-        let ret = rtshark.read();
-        assert!(ret.is_err());
+        let pkt = rtshark.read().unwrap().unwrap();
+        assert!(pkt.layer_name("nosuchproto").is_none());
 
         rtshark.kill();
 

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -24,7 +24,12 @@ impl RTSharkParser {
     }
 
     /// Main parser function used to decode XML output from tshark
-    pub(crate) fn parse(&mut self, event: Event<'_>, filters: &[String]) -> Result<ParserResult> {
+    pub(crate) fn parse(
+        &mut self,
+        event: Event<'_>,
+        blacklist: &[String],
+        whitelist: &[String],
+    ) -> Result<ParserResult> {
         // tshark pdml is something like : (default mode)
         //
         // <!-- You can find pdml2html.xsl in /usr/share/wireshark or at https://gitlab.com/wireshark/wireshark/-/raw/master/pdml2html.xsl. -->
@@ -62,7 +67,7 @@ impl RTSharkParser {
 
                 // There are cases where fields are mapped in fields. So check if there is any parent field and extract its metadata.
                 if b"field" == e.name().as_ref() {
-                    if let Some(metadata) = Self::rtshark_build_metadata(e, filters)? {
+                    if let Some(metadata) = Self::rtshark_build_metadata(e, blacklist, whitelist)? {
                         Self::add_metadata(&mut self.packet, metadata)?;
                     }
                 }
@@ -77,7 +82,9 @@ impl RTSharkParser {
                         if name == "geninfo" {
                             // Put geninfo metadata in packet's object (timestamp ...).
                             Self::geninfo_metadata(e, &mut self.packet)?;
-                        } else if let Some(metadata) = Self::rtshark_build_metadata(e, filters)? {
+                        } else if let Some(metadata) =
+                            Self::rtshark_build_metadata(e, blacklist, whitelist)?
+                        {
                             // Some dissectors place field items at the top level instead
                             // of inside a protocol. In these cases, in the PDML output the
                             // field items are placed inside a fake "<proto>" element named
@@ -101,7 +108,9 @@ impl RTSharkParser {
                                 self.packet.last_layer_mut().unwrap().add(metadata);
                             }
                         }
-                    } else if let Some(metadata) = Self::rtshark_build_metadata(e, filters)? {
+                    } else if let Some(metadata) =
+                        Self::rtshark_build_metadata(e, blacklist, whitelist)?
+                    {
                         Self::add_metadata(&mut self.packet, metadata)?;
                     }
                 }
@@ -188,7 +197,11 @@ impl RTSharkParser {
 
     /// Build a metadata using attributes available on this XML "field" tag.
     /// Sample XML line : <field name="frame.time" show="test time" pos="0" size="0" showname="test time display"/>
-    fn rtshark_build_metadata(tag: &BytesStart, filters: &[String]) -> Result<Option<Metadata>> {
+    fn rtshark_build_metadata(
+        tag: &BytesStart,
+        blacklist: &[String],
+        whitelist: &[String],
+    ) -> Result<Option<Metadata>> {
         let name = Self::rtshark_attr_by_name(tag, b"name")?;
 
         // skip "_ws.expert" info, not related to a packet metadata
@@ -196,8 +209,13 @@ impl RTSharkParser {
             return Ok(None);
         }
 
-        // skip data
-        if filters.contains(&name) {
+        // skip blacklisted fields
+        if blacklist.contains(&name) {
+            return Ok(None);
+        }
+
+        // skip fields not in the whitelist (when a whitelist is set)
+        if !whitelist.is_empty() && !whitelist.contains(&name) {
             return Ok(None);
         }
 
@@ -294,7 +312,7 @@ mod tests {
 
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(xml.as_bytes()));
 
-        let msg = RTShark::parse(&mut reader, &[]).unwrap();
+        let msg = RTShark::parse(&mut reader, &[], &[]).unwrap();
         let pkt = match msg {
             Some(p) => p,
             _ => panic!("invalid Output type"),
@@ -323,7 +341,7 @@ mod tests {
 
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(xml.as_bytes()));
 
-        let msg = RTShark::parse(&mut reader, &[]).unwrap();
+        let msg = RTShark::parse(&mut reader, &[], &[]).unwrap();
         let pkt = match msg {
             Some(p) => p,
             _ => panic!("invalid Output type"),
@@ -345,7 +363,7 @@ mod tests {
 
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(xml.as_bytes()));
 
-        let msg = RTShark::parse(&mut reader, &[]).unwrap();
+        let msg = RTShark::parse(&mut reader, &[], &[]).unwrap();
         let pkt = match msg {
             Some(p) => p,
             _ => panic!("invalid Output type"),
@@ -367,7 +385,7 @@ mod tests {
 
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(xml.as_bytes()));
 
-        let msg = RTShark::parse(&mut reader, &[]).unwrap();
+        let msg = RTShark::parse(&mut reader, &[], &[]).unwrap();
         let pkt = match msg {
             Some(p) => p,
             _ => panic!("invalid Output type"),
@@ -389,7 +407,7 @@ mod tests {
 
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(xml.as_bytes()));
 
-        let msg = RTShark::parse(&mut reader, &[]);
+        let msg = RTShark::parse(&mut reader, &[], &[]);
 
         match msg {
             Err(_) => (),
@@ -414,7 +432,7 @@ mod tests {
 
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(xml.as_bytes()));
 
-        let pkt = RTShark::parse(&mut reader, &[]).unwrap().unwrap();
+        let pkt = RTShark::parse(&mut reader, &[], &[]).unwrap().unwrap();
 
         let icmp = pkt.layer_name("icmp").unwrap();
         let data = icmp.metadata("data").unwrap();
@@ -440,7 +458,7 @@ mod tests {
 
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(xml.as_bytes()));
 
-        let pkt = RTShark::parse(&mut reader, &[]).unwrap().unwrap();
+        let pkt = RTShark::parse(&mut reader, &[], &[]).unwrap().unwrap();
 
         let icmp = pkt.layer_name("icmp").unwrap();
         let data = icmp.metadata("data").unwrap();
@@ -465,7 +483,7 @@ mod tests {
 
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(xml.as_bytes()));
 
-        let pkt = RTShark::parse(&mut reader, &[]).unwrap().unwrap();
+        let pkt = RTShark::parse(&mut reader, &[], &[]).unwrap().unwrap();
 
         let icmp = pkt.layer_name("icmp").unwrap();
         let data = icmp.metadata("data").unwrap();
@@ -486,7 +504,7 @@ mod tests {
 
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(xml.as_bytes()));
 
-        let msg = RTShark::parse(&mut reader, &[]);
+        let msg = RTShark::parse(&mut reader, &[], &[]);
         match msg {
             Err(_) => (),
             _ => panic!("invalid result"),
@@ -516,7 +534,7 @@ mod tests {
     fn test_access_packet_into_iter() {
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(XML_TCP.as_bytes()));
 
-        let msg = RTShark::parse(&mut reader, &[]).unwrap();
+        let msg = RTShark::parse(&mut reader, &[], &[]).unwrap();
         let pkt = match msg {
             Some(p) => p,
             _ => panic!("invalid Output type"),
@@ -538,7 +556,7 @@ mod tests {
     fn test_access_packet_iter() {
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(XML_TCP.as_bytes()));
 
-        let msg = RTShark::parse(&mut reader, &[]).unwrap();
+        let msg = RTShark::parse(&mut reader, &[], &[]).unwrap();
         let pkt = match msg {
             Some(p) => p,
             _ => panic!("invalid Output type"),
@@ -560,7 +578,7 @@ mod tests {
     fn test_access_layer_index() {
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(XML_TCP.as_bytes()));
 
-        let msg = RTShark::parse(&mut reader, &[]).unwrap();
+        let msg = RTShark::parse(&mut reader, &[], &[]).unwrap();
         let pkt = match msg {
             Some(p) => p,
             _ => panic!("invalid Output type"),
@@ -579,7 +597,7 @@ mod tests {
     fn test_access_layer_name() {
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(XML_TCP.as_bytes()));
 
-        let msg = RTShark::parse(&mut reader, &[]).unwrap();
+        let msg = RTShark::parse(&mut reader, &[], &[]).unwrap();
         let pkt = match msg {
             Some(p) => p,
             _ => panic!("invalid Output type"),
@@ -621,7 +639,7 @@ mod tests {
 
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(xml.as_bytes()));
 
-        let msg = RTShark::parse(&mut reader, &[]).unwrap();
+        let msg = RTShark::parse(&mut reader, &[], &[]).unwrap();
         let pkt = match msg {
             Some(p) => p,
             _ => panic!("invalid Output type"),
@@ -643,7 +661,7 @@ mod tests {
     fn test_access_layer_iter() {
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(XML_TCP.as_bytes()));
 
-        let msg = RTShark::parse(&mut reader, &[]).unwrap();
+        let msg = RTShark::parse(&mut reader, &[], &[]).unwrap();
         let pkt = match msg {
             Some(p) => p,
             _ => panic!("invalid Output type"),
@@ -660,7 +678,7 @@ mod tests {
     fn test_access_layer_into_iter() {
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(XML_TCP.as_bytes()));
 
-        let msg = RTShark::parse(&mut reader, &[]).unwrap();
+        let msg = RTShark::parse(&mut reader, &[], &[]).unwrap();
         let pkt = match msg {
             Some(p) => p,
             _ => panic!("invalid Output type"),
@@ -677,7 +695,7 @@ mod tests {
     fn test_access_layer_metadata() {
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(XML_TCP.as_bytes()));
 
-        let msg = RTShark::parse(&mut reader, &[]).unwrap();
+        let msg = RTShark::parse(&mut reader, &[], &[]).unwrap();
         let pkt = match msg {
             Some(p) => p,
             _ => panic!("invalid Output type"),
@@ -695,7 +713,7 @@ mod tests {
     fn test_parser_filter_metadata() {
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(XML_TCP.as_bytes()));
 
-        let msg = RTShark::parse(&mut reader, &["ip.src".to_string()]).unwrap();
+        let msg = RTShark::parse(&mut reader, &["ip.src".to_string()], &[]).unwrap();
         let pkt = match msg {
             Some(p) => p,
             _ => panic!("invalid Output type"),
@@ -722,19 +740,19 @@ mod tests {
         </pdml>"#;
 
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(xml.as_bytes()));
-        match RTShark::parse(&mut reader, &[]).unwrap() {
+        match RTShark::parse(&mut reader, &[], &[]).unwrap() {
             Some(p) => assert!(p.layer_name("tcp").is_some()),
             _ => panic!("invalid Output type"),
         }
-        match RTShark::parse(&mut reader, &[]).unwrap() {
+        match RTShark::parse(&mut reader, &[], &[]).unwrap() {
             Some(p) => assert!(p.layer_name("udp").is_some()),
             _ => panic!("invalid Output type"),
         }
-        match RTShark::parse(&mut reader, &[]).unwrap() {
+        match RTShark::parse(&mut reader, &[], &[]).unwrap() {
             Some(p) => assert!(p.layer_name("igmp").is_some()),
             _ => panic!("invalid Output type"),
         }
-        match RTShark::parse(&mut reader, &[]).unwrap() {
+        match RTShark::parse(&mut reader, &[], &[]).unwrap() {
             None => (),
             _ => panic!("invalid Output type"),
         }
@@ -759,7 +777,7 @@ mod tests {
         </pdml>"#;
 
         let mut reader = quick_xml::Reader::from_reader(BufReader::new(xml.as_bytes()));
-        match RTShark::parse(&mut reader, &[]).unwrap() {
+        match RTShark::parse(&mut reader, &[], &[]).unwrap() {
             Some(p) => match p.layer_name("btcommon") {
                 Some(layer) => {
                     layer


### PR DESCRIPTION
This should fix issue https://github.com/CrabeDeFrance/rtshark/issues/36 , but I'm not sure if it's in the best way possible.
This removes extracting fields using `-E` option, as if that's used, then it will remove the entire structure of the document.
Instead it will just ignore fields which are not in the whitelist. Which... I'm not sure how much it affects performance, but hopefully not too much.

This now allows to do something like:

```rs
for group in tls_layer.groups("tls.record") {
    println!("{:?}", group.parent.display());
    for field in &group.fields {
        println!("  {} = {}", field.name(), field.value());
    }
}
```

The changes are not too invasive, but it still does change something quite fundamental. Keep in mind, that it would require the parent name to be included in the whitelist as well.

E.g. for `tls.record.length` and `tls.record.content_type`, to get them as a group `tls.record` would need to be in the whitelist as well. This could potentially be automated.

I'm happy to hear any thoughts on this!

Also full disclosure, I used AI to help make this PR. The only thing I'm not  sure about are the lifetimes.

EDIT: Also noting, it seems like a hack to use the bytes/pos/size to figure out the children of a group, but it also seems to work quite nicely. It could also be integrated into the code, to dive into each group instead, but that would be a bit more complicated.