### PR TITLE
Issue #36: adds support for capturing groups of metadata - optimization

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -729,6 +729,30 @@ impl<'a> RTSharkBuilderReady<'a> {
             tshark_params.extend(&["-o", option]);
         }
 
+        if !self.metadata_whitelist.is_empty() {
+            // check if there are grouped metadata on whitelist => we can't use -e option
+            // Tshark output becomes very messy when there are subtypes, they are not in a logical order anymore, see the following example :
+            // tshark -r ./assets/test_tls.pcap -n -Q -Y "frame.number == 6" -e tls.record -e tls.record.content_type -e tls.record.length -e tls -Tpdml -l
+            //   <field name="tls.record" value="1"/>
+            //   <field name="tls.record" value="1"/>
+            //   <field name="tls.record.content_type" value="22"/>
+            //   <field name="tls.record.content_type" value="20"/>
+            //   <field name="tls.record.length" value="122"/>
+            //   <field name="tls.record.length" value="1"/>
+            //   <field name="tls" value="tls"/>
+
+            let can_use_e_option = self
+                .metadata_whitelist
+                .iter()
+                .all(|elem| elem.chars().filter(|&c| c == '.').count() < 2);
+
+            if can_use_e_option {
+                for whitelist_elem in &self.metadata_whitelist {
+                    tshark_params.extend(&["-e", whitelist_elem]);
+                }
+            }
+        }
+
         for protocol in &self.disabled_protocols {
             tshark_params.extend(&["--disable-protocol", protocol]);
         }

--- a/src/rtshark.rs
+++ b/src/rtshark.rs
@@ -514,8 +514,8 @@ mod tests {
 
         // whitelist filtering is now done at parse time, so tshark succeeds but
         // no metadata matching the non-existent field is stored
-        let pkt = rtshark.read().unwrap().unwrap();
-        assert!(pkt.layer_name("nosuchproto").is_none());
+        let ret = rtshark.read();
+        assert!(ret.is_err());
 
         rtshark.kill();
 

--- a/src/rtshark_async.rs
+++ b/src/rtshark_async.rs
@@ -565,8 +565,8 @@ mod tests {
         let mut rtshark = builder.spawn().unwrap();
 
         // read a packet
-        let pkt = rtshark.read().unwrap().unwrap();
-        assert!(pkt.layer_name("nosuchproto").is_none());
+        let ret = rtshark.read();
+        assert!(ret.is_err());
 
         rtshark.kill();
 


### PR DESCRIPTION
Do not use -e option only when there are groups of metadata. Prevent performance decrease in standard case.